### PR TITLE
Implement activation functions and plotting utility

### DIFF
--- a/activation.py
+++ b/activation.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+class ActivationFunction:
+    def __init__(self, name, alpha=0.01):
+        self.name = name.lower()
+        self.alpha = alpha
+
+    def apply(self, z):
+        z = np.array(z)
+        if self.name == "heaviside":
+            return np.where(z >= 0, 1.0, 0.0)
+        elif self.name == "sigmoid":
+            return 1.0 / (1.0 + np.exp(-z))
+        elif self.name == "tanh":
+            return np.tanh(z)
+        elif self.name == "relu":
+            return np.maximum(0, z)
+        elif self.name == "leaky_relu":
+            return np.where(z >= 0, z, self.alpha * z)
+        else:
+            raise ValueError(f"Activation '{self.name}' non reconnue.")
+
+    def derivative(self, z):
+        z = np.array(z)
+        if self.name == "heaviside":
+            # Approximation: zero everywhere
+            return np.zeros_like(z)
+        elif self.name == "sigmoid":
+            s = self.apply(z)
+            return s * (1 - s)
+        elif self.name == "tanh":
+            t = np.tanh(z)
+            return 1 - t**2
+        elif self.name == "relu":
+            return np.where(z > 0, 1.0, 0.0)
+        elif self.name == "leaky_relu":
+            return np.where(z > 0, 1.0, self.alpha)
+        else:
+            raise ValueError(f"Dérivée de '{self.name}' non définie.")

--- a/plot_activation_functions.py
+++ b/plot_activation_functions.py
@@ -1,0 +1,22 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from activation import ActivationFunction
+
+
+def plot_activation(name, alpha=0.01):
+    z = np.linspace(-10, 10, 400)
+    act = ActivationFunction(name, alpha)
+    g = act.apply(z)
+    dg = act.derivative(z)
+
+    plt.figure()
+    plt.plot(z, g, label=name)
+    plt.plot(z, dg, label=f"d{name}/dz")
+    plt.title(name)
+    plt.legend()
+    plt.grid(True)
+    plt.savefig(f"{name}.png")
+
+if __name__ == "__main__":
+    for name in ["heaviside", "sigmoid", "tanh", "relu", "leaky_relu"]:
+        plot_activation(name)


### PR DESCRIPTION
## Summary
- add `ActivationFunction` class with several activation functions and derivatives
- add script to plot the functions and their derivatives

## Testing
- `python plot_activation_functions.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68666c0810708323af777dfb4f5ba39e